### PR TITLE
Fix rs9116Wifi module fails to load because the build strips binaries…

### DIFF
--- a/meta-adv-imx/recipes-kernel/rs9116nb0/files/0001_change_COEX_MODE.patch
+++ b/meta-adv-imx/recipes-kernel/rs9116nb0/files/0001_change_COEX_MODE.patch
@@ -1,0 +1,12 @@
+diff a/source/host/release/release/common_insert.sh b/source/host/release/common_insert.sh
+--- a/source/host/release/common_insert.sh	
++++ b/source/host/release/common_insert.sh	
+@@ -25,7 +25,7 @@
+ #							13   WLAN STATION + BT CLASSIC MODE + BT LE MODE
+ #							14   WLAN ACCESS POINT + BT CLASSIC MODE+ BT LE MODE
+ 
+-COEX_MODE=1
++COEX_MODE=13
+ 
+ #To enable TA-level SDIO aggregation set 1 else set 0 to disable it.
+ TA_AGGR=8

--- a/meta-adv-imx/recipes-kernel/rs9116nb0/files/startup_wlan_bt.sh
+++ b/meta-adv-imx/recipes-kernel/rs9116nb0/files/startup_wlan_bt.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+rs9116_wifi=`/usr/bin/lsusb | grep 1618:9116 | wc -l`
+[ "$rs9116_wifi" == "0" ] && exit 0
+
 TARGET_DIR=`cd "$(dirname "$0")"; pwd`
 cd ${TARGET_DIR}/
 

--- a/meta-adv-imx/recipes-kernel/rs9116nb0/rs9116nb0_2.3.0.0001.bb
+++ b/meta-adv-imx/recipes-kernel/rs9116nb0/rs9116nb0_2.3.0.0001.bb
@@ -10,7 +10,9 @@ inherit pkgconfig systemd
 SRC_URI = "file://rs9116nb0.2.3.0.0001.tar.bz2 \
 		file://defconfig \
 		file://startup_wlan_bt.sh \
-		file://wifibt.service"
+		file://wifibt.service \
+		file://0001_change_COEX_MODE.patch \
+" 
 
 RDEPENDS_${PN} = "bash"
 
@@ -37,6 +39,7 @@ do_install() {
 	fi
 
 	## install the release
+
 	install -m 755 ${B}/release/*_util     ${D}/usr/local/wifibt/
 	install -m 755 ${B}/release/*_transmit     ${D}/usr/local/wifibt/
 	install -m 755 ${B}/release/ant_encryption     ${D}/usr/local/wifibt/
@@ -87,3 +90,4 @@ FILES_${PN} += "${exec_prefix} ${systemd_system_unitdir}"
 ## Since no pass LDFLAGS for these program, so we
 ## we must skip the qa check
 INSANE_SKIP_${PN} += "ldflags"
+INHIBIT_PACKAGE_STRIP = "1" 

--- a/meta-adv-imx/recipes-utils/gester/gester.bb
+++ b/meta-adv-imx/recipes-utils/gester/gester.bb
@@ -22,8 +22,6 @@ INHIBIT_PACKAGE_STRIP = "1"
 
 do_compile() {
         oe_runmake LD="${CXX}" CC="${CC}" CXX="${CXX}" AR="${AR}"
-#	oe_runmake LD="${CXX}" CC="${CC}" CFLAGS="${CFLAGS}" CXX="${CXX}" AR="${AR}"
-#       oe_runmake CXX="${CXX}" CFLAGS="${CFLAGS}"
 }
 
 do_install() {	


### PR DESCRIPTION
… in generated package